### PR TITLE
Fix dropdown width overflowing

### DIFF
--- a/style.css
+++ b/style.css
@@ -48,6 +48,8 @@ input[type="text"], select {
 /* Compact Choices.js dropdown styling */
 .choices {
   font-size: 0.95rem;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .choices__inner {
@@ -61,6 +63,8 @@ input[type="text"], select {
 
 .choices__list--dropdown {
   font-size: 0.95rem;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 button {


### PR DESCRIPTION
## Summary
- ensure Choices dropdowns have full container width

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c367b2e60832cae8443e91fe45632