### PR TITLE
Fix logo scaling and align totals right

### DIFF
--- a/script.js
+++ b/script.js
@@ -190,7 +190,10 @@ async function generatePDF() {
     reader.readAsDataURL(blob);
   }));
 
-  doc.addImage(logo, "PNG", 15, 10, 40, 15);
+  const imgProps = doc.getImageProperties(logo);
+  const logoWidth = 40;
+  const logoHeight = (imgProps.height * logoWidth) / imgProps.width;
+  doc.addImage(logo, "PNG", 15, 10, logoWidth, logoHeight);
   doc.setFontSize(16);
   doc.text("Quoted Repair Estimator", 105, 20, { align: "center" });
 
@@ -233,9 +236,11 @@ async function generatePDF() {
   const total = subtotal + vat;
   const finalY = doc.lastAutoTable.finalY || 60;
 
-  doc.text(`Subtotal: £${subtotal.toFixed(2)}`, 15, finalY + 10);
-  doc.text(`VAT: £${vat.toFixed(2)}`, 15, finalY + 16);
-  doc.text(`Total: £${total.toFixed(2)}`, 15, finalY + 22);
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const rightMargin = pageWidth - 15;
+  doc.text(`Subtotal: £${subtotal.toFixed(2)}`, rightMargin, finalY + 10, { align: "right" });
+  doc.text(`VAT: £${vat.toFixed(2)}`, rightMargin, finalY + 16, { align: "right" });
+  doc.text(`Total: £${total.toFixed(2)}`, rightMargin, finalY + 22, { align: "right" });
 
   doc.text(`Supply Only: ${document.getElementById("supplyOnly").checked ? "Yes" : "No"}`, 105, finalY + 10);
   doc.text(`VAT Exempt: ${document.getElementById("vatExempt").checked ? "Yes" : "No"}`, 105, finalY + 16);

--- a/style.css
+++ b/style.css
@@ -17,7 +17,8 @@ body {
 }
 
 .logo {
-  height: 60px;
+  width: 150px;
+  height: auto;
 }
 
 h1 {
@@ -142,6 +143,7 @@ button {
   margin-top: 15px;
   border-left: 5px solid #4caf50;
   border-radius: 6px;
+  text-align: right;
 }
 
 .hidden {


### PR DESCRIPTION
## Summary
- maintain logo aspect ratio when generating PDF
- limit logo size on page and make totals right-aligned
- align totals to the right in generated PDF

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c36a7efec832cb75c0157af2946ea