### PR TITLE
Improve quote layout and dropdown sizing

### DIFF
--- a/script.js
+++ b/script.js
@@ -143,11 +143,11 @@ function renderQuote() {
 
     quoteLines.innerHTML += `
       <div class="quote-line">
-        <p><strong>${item.asset} → ${item.make} → ${item.repair}</strong></p>
-        <p>Part #: ${info.part_number}</p>
-        <p>Labour: ${supplyOnly ? 'N/A' : `£${labour.toFixed(2)}`}</p>
-        <p>Materials: £${info.material_cost.toFixed(2)}</p>
-        <p><strong>Total: £${total.toFixed(2)}</strong></p>
+        <p class="desc"><strong>${item.asset} → ${item.make} → ${item.repair}</strong></p>
+        <p><span class="label">Part #:</span><span class="value">${info.part_number}</span></p>
+        <p><span class="label">Labour:</span><span class="value">${supplyOnly ? 'N/A' : `£${labour.toFixed(2)}`}</span></p>
+        <p><span class="label">Materials:</span><span class="value">£${info.material_cost.toFixed(2)}</span></p>
+        <p class="total-line"><strong class="label">Total:</strong><strong class="value">£${total.toFixed(2)}</strong></p>
         <button onclick="removeItem(${index})">Remove</button>
       </div>
     `;
@@ -157,8 +157,7 @@ function renderQuote() {
     subtotal += carriageCharge;
     quoteLines.innerHTML += `
       <div class="quote-line">
-        <p><strong>Carriage</strong></p>
-        <p><strong>Total: £${carriageCharge.toFixed(2)}</strong></p>
+        <p><strong class="label">Carriage</strong><strong class="value">£${carriageCharge.toFixed(2)}</strong></p>
       </div>
     `;
   }

--- a/style.css
+++ b/style.css
@@ -19,6 +19,7 @@ body {
 .logo {
   width: 150px;
   height: auto;
+  max-width: 100%;
 }
 
 h1 {
@@ -49,7 +50,7 @@ input[type="text"], select {
 /* Compact Choices.js dropdown styling */
 .choices {
   font-size: 0.95rem;
-  width: 100%;
+  width: 100% !important;
   box-sizing: border-box;
 }
 
@@ -64,7 +65,7 @@ input[type="text"], select {
 
 .choices__list--dropdown {
   font-size: 0.95rem;
-  width: 100%;
+  width: 100% !important;
   box-sizing: border-box;
 }
 
@@ -124,6 +125,20 @@ button {
   padding: 10px;
   border-left: 4px solid #ccc;
   border-radius: 6px;
+}
+
+.quote-line p {
+  display: flex;
+  justify-content: space-between;
+  margin: 4px 0;
+}
+
+.quote-line .value {
+  margin-left: 10px;
+}
+
+.total-line {
+  font-weight: bold;
 }
 
 .quote-line button {


### PR DESCRIPTION
## Summary
- widen dropdown components with `!important`
- ensure logo scales with container
- align quote line prices using flex styling
- keep carriage as a separate row

## Testing
- `npm test` *(fails: could not find package.json)*
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684c3882c250832c8d1a47536f5d3f81