### PR TITLE
Fix dropdown width and pdf title

### DIFF
--- a/script.js
+++ b/script.js
@@ -197,8 +197,9 @@ async function generatePDF() {
   const logoWidth = 40;
   const logoHeight = (imgProps.height * logoWidth) / imgProps.width;
   doc.addImage(logo, "PNG", 15, 10, logoWidth, logoHeight);
+  const titleY = 10 + logoHeight + 5;
   doc.setFontSize(16);
-  doc.text("Quoted Repair Estimator", 105, 20, { align: "center" });
+  doc.text("Quoted Repair Estimate", 105, titleY, { align: "center" });
 
   const name = document.getElementById("customerName").value || "(No name)";
   const number = document.getElementById("quoteNumber").value || "(No #)";

--- a/style.css
+++ b/style.css
@@ -13,7 +13,7 @@ body {
 
 .logo-container {
   text-align: center;
-  margin-bottom: 10px;
+  margin-bottom: 20px;
 }
 
 .logo {
@@ -24,7 +24,7 @@ body {
 
 h1 {
   text-align: center;
-  margin-bottom: 25px;
+  margin: 20px 0 25px;
   font-size: 26px;
 }
 
@@ -61,6 +61,8 @@ input[type="text"], select {
   border-radius: 6px !important;
   border: 1px solid #ccc !important;
   box-shadow: none !important;
+  width: 100% !important;
+  box-sizing: border-box !important;
 }
 
 .choices__list--dropdown {


### PR DESCRIPTION
## Summary
- adjust margin around logo and heading
- ensure dropdowns fill the form width
- fix pdf title and spacing so text no longer overlaps the logo

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c3c2c9cc4832cbf68690824e78f4d