### PR TITLE
Add email and phone inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,16 @@
       </div>
 
       <div class="form-group">
+        <label for="customerEmail">Customer Email:</label>
+        <input type="text" id="customerEmail" placeholder="e.g. example@example.com" />
+      </div>
+
+      <div class="form-group">
+        <label for="customerPhone">Customer Phone:</label>
+        <input type="text" id="customerPhone" placeholder="e.g. 01234 567890" />
+      </div>
+
+      <div class="form-group">
         <label for="quoteNumber">Quote Number:</label>
         <input type="text" id="quoteNumber" placeholder="e.g. Q12345" />
       </div>

--- a/script.js
+++ b/script.js
@@ -201,11 +201,17 @@ async function generatePDF() {
   doc.text("Quoted Repair Estimator", 105, 20, { align: "center" });
 
   const name = document.getElementById("customerName").value || "(No name)";
+  const email = document.getElementById("customerEmail").value || "";
+  const phone = document.getElementById("customerPhone").value || "";
   const number = document.getElementById("quoteNumber").value || "(No #)";
   doc.setFontSize(10);
   doc.text(`Quote #: ${number}`, 15, 32);
   doc.text(`Customer: ${name}`, 15, 38);
-  doc.text(`Date: ${new Date().toLocaleDateString()}`, 15, 44);
+  if (email) doc.text(`Email: ${email}`, 15, 44);
+  if (phone) doc.text(`Phone: ${phone}`, 15, email ? 50 : 44);
+  const dateY = email && phone ? 56 : (email || phone ? 50 : 44);
+  doc.text(`Date: ${new Date().toLocaleDateString()}`, 15, dateY);
+  const tableStartY = dateY + 6;
 
   const rows = quoteItems.map(item => {
     const info = data[item.asset][item.make][item.repair];
@@ -228,7 +234,7 @@ async function generatePDF() {
   }
 
   doc.autoTable({
-    startY: 50,
+    startY: tableStartY,
     head: [["Asset", "Repair", "Part#", "Labour", "Materials", "Total"]],
     body: rows
   });


### PR DESCRIPTION
## Summary
- add fields to capture customer email and phone
- include optional email and phone information in generated PDF

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684c3c6cf48c832cbfb205b89ade2e2b