### PR TITLE
Fix PDF header color and reduce logo size

### DIFF
--- a/script.js
+++ b/script.js
@@ -202,12 +202,12 @@ async function generatePDF() {
     );
 
   // Header band
-  doc.setFillColor(39, 72, 143);
+  doc.setFillColor(245, 245, 245);
   doc.rect(0, 0, pageWidth, 25, "F");
 
   // Logo and title
   doc.addImage(logo, "PNG", 10, 5, 20, 15);
-  doc.setTextColor(255, 255, 255);
+  doc.setTextColor(39, 72, 143);
   doc.setFontSize(16);
   // Title displayed prominently at the top of the page
   doc.text("Quoted Repair Estimate", pageWidth / 2, 12, { align: "center" });

--- a/style.css
+++ b/style.css
@@ -17,7 +17,7 @@ body {
 }
 
 .logo {
-  width: 150px;
+  width: 130px;
   height: auto;
   max-width: 100%;
 }


### PR DESCRIPTION
## Summary
- tweak PDF header background to avoid color clashes
- use blue text for PDF title
- reduce logo width in the main page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d5a95b374832ca5c9b204f4e749eb