### PR TITLE
Improve sales quoting flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,10 +117,6 @@
         <input type="text" id="salesDesc" placeholder="Product" />
       </div>
 
-      <div class="form-group">
-        <label for="salesPrice">Price:</label>
-        <input type="number" step="0.01" id="salesPrice" placeholder="e.g. 99.99" />
-      </div>
 
       <div class="form-group">
         <label for="salesQty">Quantity:</label>


### PR DESCRIPTION
## Summary
- remove price field from sales form
- store default prices in `salesData`
- calculate sales item price from lookup
- add automatic carriage charge of £15.95 to sales quotes
- match Sales PDF header styling to Repair PDF

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684e089ee5a8832ca2b62abb10e28037