### PR TITLE
Fix pricing display

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ Tool for estimating repair and sales quotes for mobility equipment.
 - When a sales item is chosen its configured cost and default selling price are loaded
   automatically. The tool calculates the profit margin between those values and shows
   it in an editable field so the margin or final price can be adjusted on the fly.
+- Cost on sales items is now read-only and the customer price fields and quote output
+  explicitly show values excluding VAT.

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
 
       <div class="form-group">
         <label for="salesCost">Our Cost:</label>
-        <input type="number" id="salesCost" step="0.01" />
+        <input type="number" id="salesCost" step="0.01" readonly />
       </div>
 
       <div class="form-group">
@@ -128,7 +128,7 @@
       </div>
 
       <div class="form-group">
-        <label for="salesPrice">Customer Price:</label>
+        <label for="salesPrice">Customer Price (ex VAT):</label>
         <input type="number" id="salesPrice" step="0.01" />
       </div>
 

--- a/script.js
+++ b/script.js
@@ -138,7 +138,6 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   document.getElementById("salesMargin").addEventListener("input", updatePriceFromMargin);
-  document.getElementById("salesCost").addEventListener("input", updatePriceFromMargin);
   document.getElementById("salesPrice").addEventListener("input", updateMarginFromPrice);
 
   document.getElementById("addItem").addEventListener("click", () => {
@@ -457,7 +456,7 @@ function renderSalesQuote() {
         <p class="desc"><strong>${item.asset} → ${item.make}</strong></p>
         <p><span class="label">Cost:</span><span class="value">£${item.cost.toFixed(2)}</span></p>
         <p><span class="label">Margin:</span><span class="value">${item.margin.toFixed(2)}%</span></p>
-        <p><span class="label">Price:</span><span class="value">£${item.price.toFixed(2)}</span></p>
+        <p><span class="label">Price (ex VAT):</span><span class="value">£${item.price.toFixed(2)}</span></p>
         <p><span class="label">Qty:</span><span class="value">${item.qty}</span></p>
         <p class="total-line"><strong class="label">Total:</strong><strong class="value">£${total.toFixed(2)}</strong></p>
         <button onclick="removeSalesItem(${index})">Remove</button>
@@ -550,7 +549,7 @@ async function generateSalesPDF() {
 
   doc.autoTable({
     startY: tableStartY,
-    head: [["Item", "Qty", "Price", "Total"]],
+    head: [["Item", "Qty", "Price (ex VAT)", "Total"]],
     body: rows,
     margin: { left: 15, right: 15 },
     theme: "grid",


### PR DESCRIPTION
## Summary
- make "Our Cost" read-only so it's not changed accidentally
- clarify pricing as ex VAT in the UI and PDF

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ebd14f044832c8f9d5fb1b28d015c