### PR TITLE
Set sales margin default to 35%

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
 
       <div class="form-group">
         <label for="salesMargin">Profit Margin %:</label>
-        <input type="number" id="salesMargin" value="20" step="0.01" />
+        <input type="number" id="salesMargin" value="35" step="0.01" />
       </div>
 
       <div class="form-group">


### PR DESCRIPTION
## Summary
- default profit margin on sales order form from 20% to 35%

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ebf708aa0832cafd1a00a01d03349