### PR TITLE
Add labour input and new repair data

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,11 @@
         </select>
       </div>
 
+      <div id="labourSection" class="form-group hidden">
+        <label for="labourHours">Labour (hrs):</label>
+        <input type="number" id="labourHours" step="0.25" placeholder="Default labour" />
+      </div>
+
       <button type="button" id="addItem">+ Add Item to Quote</button>
 
       <div class="checkboxes">


### PR DESCRIPTION
## Summary
- add new Profile Bed and Portable Ceiling Hoist repair data
- introduce labour hours input field for repairs
- allow setting labour hours per line item with £74.75 default when blank

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684fbf0641d4832c8b5369b3ffbdaaca