### PR TITLE
Add setup and commission options for sales items

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,6 +143,11 @@
         <input type="number" id="salesQty" value="1" />
       </div>
 
+      <div id="salesExtras" class="form-group hidden">
+        <label id="setupLabel"><input type="checkbox" id="includeSetup" /> Include Setup</label>
+        <label id="commissionLabel"><input type="checkbox" id="includeCommission" /> Include Commission</label>
+      </div>
+
       <button type="button" id="addSalesItem">+ Add Item to Quote</button>
 
       <div class="checkboxes">

--- a/style.css
+++ b/style.css
@@ -153,6 +153,13 @@ button {
   transform: scale(0.9);
 }
 
+#salesExtras {
+  display: flex;
+  gap: 15px;
+  margin-top: 10px;
+  font-weight: 500;
+}
+
 .quote-section {
   margin-top: 25px;
   background: white;


### PR DESCRIPTION
## Summary
- enable optional setup and commission charges for some sales assets
- show checkboxes when an item supports those extras
- render extras in the quote and PDF
- style the new options section

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684ffd558ccc832c82bd68b3d4b522b6