### PR TITLE
Add work description field and disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ Tool for estimating repair and sales quotes for mobility equipment.
   quote. The page now displays this requirement instead of listing it on quotes.
 - Added repair options for Parker Rise & Tilt baths and Casa Classic FS beds
   while removing the placeholder Oxford Midi hoist entries.
+- Repair quotes now include an optional work description and a disclaimer that
+  the estimate is subject to final approval before any work is carried out.

--- a/index.html
+++ b/index.html
@@ -43,6 +43,11 @@
       </div>
 
       <div class="form-group">
+        <label for="workDesc">Work Description (optional):</label>
+        <input type="text" id="workDesc" placeholder="Brief description of work" />
+      </div>
+
+      <div class="form-group">
         <label for="assetSelect">Asset Type:</label>
         <select id="assetSelect">
           <option value="" disabled selected>Select Asset</option>

--- a/script.js
+++ b/script.js
@@ -470,6 +470,7 @@ async function generatePDF() {
   const name = document.getElementById("customerName").value || "(No name)";
   const email = document.getElementById("customerEmail").value || "";
   const phone = document.getElementById("customerPhone").value || "";
+  const desc = document.getElementById("workDesc").value || "";
   const number = document.getElementById("quoteNumber").value || "(No #)";
   doc.setFontSize(11);
   let infoY = infoStartY;
@@ -483,6 +484,11 @@ async function generatePDF() {
   doc.text(`Email: ${email || "(N/A)"}`, 15, infoY);
   infoY += 6;
   doc.text(`Date: ${new Date().toLocaleDateString()}`, 15, infoY);
+  infoY += 6;
+  if (desc) {
+    doc.text(`Work: ${desc}`, 15, infoY);
+    infoY += 6;
+  }
   const tableStartY = infoY + 8;
 
   const rows = [];
@@ -565,7 +571,16 @@ async function generatePDF() {
   }
   if (document.getElementById("vatExempt").checked) {
     doc.text("VAT Exempt: Yes", centreX, noteY, { align: "center" });
+    noteY += 6;
   }
+
+  doc.setFontSize(10);
+  doc.text("This repair quote is an estimate only.", centreX, noteY, { align: "center" });
+  noteY += 5;
+  doc.text("A final quote will be sent for your approval and work will", centreX, noteY, { align: "center" });
+  noteY += 5;
+  doc.text("proceed only once that quote has been accepted.", centreX, noteY, { align: "center" });
+  doc.setFontSize(11);
 
   const footerY = doc.internal.pageSize.getHeight() - 10;
   doc.text("Thank you for choosing NHM. Please contact us with any questions.", centreX, footerY, { align: "center" });


### PR DESCRIPTION
## Summary
- add optional work description to repair form
- include description in repair PDF
- add disclaimer that repair quote is an estimate
- document new feature

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68502ed599a8832c82a6a39d843388af