### PR TITLE
Fix checkbox label alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -149,6 +149,16 @@ button {
   font-weight: 500;
 }
 
+/* Ensure the checkbox labels align nicely with the custom boxes */
+.checkboxes label,
+#salesExtras label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 0;
+  font-weight: 500;
+}
+
 .checkboxes input[type="checkbox"],
 #salesExtras input[type="checkbox"],
 input[type="checkbox"] {
@@ -162,6 +172,7 @@ input[type="checkbox"] {
   cursor: pointer;
   transition: background 0.2s, transform 0.1s;
   display: inline-block;
+  vertical-align: middle;
 }
 
 .checkboxes input[type="checkbox"]:checked,


### PR DESCRIPTION
## Summary
- align custom checkbox labels with the boxes
- vertically center checkbox inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68504f80fbf0832c9aaca0d4973a32e6