### PR TITLE
Remove CFS headboard from Casa Classic FS

### DIFF
--- a/script.js
+++ b/script.js
@@ -24,17 +24,6 @@ const data = {
         }
       }
     },
-    "Casa": {
-      "Classic FS": {
-        "Standard": {
-          "CFS Headboard Wooden": {
-            labour_hours: 0.5,
-            material_cost: 150.33,
-            part_number: "SPX055-0110",
-          }
-        }
-      }
-    },
     "Drive DeVilbiss": {
       "Sidhill / Bradshaw": {
         "Bradshaw Standard": {


### PR DESCRIPTION
## Summary
- remove `CFS Headboard Wooden` repair option for Casa Classic FS beds

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_68532033a49c832c8a727097fb4c44f4