### PR TITLE
Add custom labour override

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ Tool for estimating repair and sales quotes for mobility equipment.
   dedicated "Description of work(s)" box above the line items.
 - PDFs now show this description in a matching box when text is entered.
 - PDF exports redesigned with boxed sections and clearer disclaimers at the bottom.
+- Added an option to override the default £74.75 minimum labour charge when
+  preparing a repair quote.

--- a/index.html
+++ b/index.html
@@ -92,6 +92,11 @@
 
       <button type="button" id="addItem">+ Add Item to Quote</button>
 
+      <div class="form-group">
+        <label><input type="checkbox" id="overrideLabour" /> Override Minimum Labour</label>
+        <input type="number" id="customLabour" step="0.01" value="74.75" class="hidden" />
+      </div>
+
       <div class="checkboxes">
         <label><input type="checkbox" id="supplyOnly" /> Supply Only</label>
         <label><input type="checkbox" id="vatExempt" /> VAT Exempt</label>

--- a/script.js
+++ b/script.js
@@ -214,7 +214,8 @@ const data = {
 const SALES_CARRIAGE = 15.95;
 // Labour pricing constants
 const LABOUR_RATE = 30.5; // £15.25 per 0.5 hour
-const MIN_LABOUR_COST = 74.75;
+const DEFAULT_MIN_LABOUR_COST = 74.75;
+let minLabourCost = DEFAULT_MIN_LABOUR_COST;
 // Cost and default selling price for sales items
   const salesData = {
     "Hoist": {
@@ -487,6 +488,25 @@ document.addEventListener("DOMContentLoaded", () => {
 
   document.getElementById("supplyOnly").addEventListener("change", renderQuote);
   document.getElementById("vatExempt").addEventListener("change", renderQuote);
+  document.getElementById("overrideLabour").addEventListener("change", () => {
+    const input = document.getElementById("customLabour");
+    if (document.getElementById("overrideLabour").checked) {
+      input.classList.remove("hidden");
+      const val = parseFloat(input.value);
+      minLabourCost = isNaN(val) ? DEFAULT_MIN_LABOUR_COST : val;
+    } else {
+      input.classList.add("hidden");
+      minLabourCost = DEFAULT_MIN_LABOUR_COST;
+    }
+    renderQuote();
+  });
+  document.getElementById("customLabour").addEventListener("input", () => {
+    if (document.getElementById("overrideLabour").checked) {
+      const val = parseFloat(document.getElementById("customLabour").value);
+      minLabourCost = isNaN(val) ? DEFAULT_MIN_LABOUR_COST : val;
+      renderQuote();
+    }
+  });
   document.getElementById("workDesc").addEventListener("input", renderQuote);
   document.getElementById("downloadPDF").addEventListener("click", generatePDF);
 
@@ -673,10 +693,10 @@ function renderQuote() {
     return { item, info, labour, labourPerItem };
   });
 
-  if (!supplyOnly && items.length > 0 && labourSubtotal < MIN_LABOUR_COST) {
-    const diff = MIN_LABOUR_COST - labourSubtotal;
+  if (!supplyOnly && items.length > 0 && labourSubtotal < minLabourCost) {
+    const diff = minLabourCost - labourSubtotal;
     items[0].labour += diff;
-    labourSubtotal = MIN_LABOUR_COST;
+    labourSubtotal = minLabourCost;
   }
 
   items.forEach(({ item, info, labour }, index) => {
@@ -808,10 +828,10 @@ async function generatePDF() {
     return { item, info, labour };
   });
 
-  if (!supplyOnlyFlag && items.length > 0 && labourSubtotal < MIN_LABOUR_COST) {
-    const diff = MIN_LABOUR_COST - labourSubtotal;
+  if (!supplyOnlyFlag && items.length > 0 && labourSubtotal < minLabourCost) {
+    const diff = minLabourCost - labourSubtotal;
     items[0].labour += diff;
-    labourSubtotal = MIN_LABOUR_COST;
+    labourSubtotal = minLabourCost;
   }
 
   items.forEach(({ item, info, labour }) => {


### PR DESCRIPTION
## Summary
- let users override the minimum labour charge for repair quotes
- show field when 'Override Minimum Labour' is ticked
- update calculations and PDF generation to use custom value
- document new override feature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685320c798c4832cb7702b6446ff8bbe