### PR TITLE
Fix sales PDF generation

### DIFF
--- a/script.js
+++ b/script.js
@@ -1190,6 +1190,8 @@ async function generateSalesPDF() {
   const doc = new jsPDF();
 
   const pageWidth = doc.internal.pageSize.getWidth();
+  const pageHeight = doc.internal.pageSize.getHeight();
+  const margin = 15;
 
   const logo = await fetch("nhm-logo.png")
     .then(r => r.blob())


### PR DESCRIPTION
## Summary
- ensure `generateSalesPDF` defines `pageHeight` and `margin`

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68532f370ee0832c893c400819bbf6fe