### PR TITLE
Show equipment sales parts as disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ Tool for estimating repair and sales quotes for mobility equipment.
 - PDF exports redesigned with boxed sections and clearer disclaimers at the bottom.
 - Added an option to override the default £74.75 minimum labour charge when
   preparing a repair quote.
+- Repair dropdown now shows equipment sales parts in grey with an
+  "Equipment Sales" tag.

--- a/script.js
+++ b/script.js
@@ -722,7 +722,14 @@ function populateRepairs() {
   const select = document.getElementById("repairSelect");
   repairChoices.destroy();
   select.innerHTML = `<option value="" disabled selected>Select Repair</option>` +
-    repairs.map(r => `<option value="${r}">${r}</option>`).join("");
+    repairs
+      .map(r => {
+        const info = data[asset]?.[make]?.[model]?.[variant]?.[category]?.[r];
+        const isEq = info && info.part_number && info.part_number.startsWith("EQ");
+        const label = isEq ? `${r} (Equipment Sales)` : r;
+        return `<option value="${r}" ${isEq ? "disabled" : ""}>${label}</option>`;
+      })
+      .join("");
   repairChoices = new Choices(select, {
     searchEnabled: true,
     shouldSort: false,

--- a/style.css
+++ b/style.css
@@ -70,6 +70,10 @@ input[type="text"], select {
   box-sizing: border-box;
 }
 
+select option[disabled] {
+  color: #999;
+}
+
 /* Compact Choices.js dropdown styling */
 .choices {
   font-size: 0.95rem;
@@ -86,6 +90,10 @@ input[type="text"], select {
   box-shadow: none !important;
   width: 100% !important;
   box-sizing: border-box !important;
+}
+
+.choices__item--disabled {
+  opacity: 0.5;
 }
 
 .choices__list--dropdown {


### PR DESCRIPTION
## Summary
- mark equipment sales parts in the repair dropdown
- grey out disabled dropdown options
- document the new equipment sales tag in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685718b484d0832ca242a0c85391922b