### PR TITLE
Fix syntax around bed data

### DIFF
--- a/script.js
+++ b/script.js
@@ -299,7 +299,8 @@ const data = {
               material_cost: 1217.34,
               part_number: "EQ055-0014",
             }
-=======
+          }
+        },
       "Sidhill / Bradshaw": {
         "Bradshaw Standard": {
           "Accessories & Fittings": {


### PR DESCRIPTION
## Summary
- remove stray merge marker and add missing braces in the bed asset data

## Testing
- `node --check script.js` *(fails: SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_68587f89d988832cb11b9d6d7ffff3ac