### PR TITLE
Add optional setup & commission option

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,6 +205,7 @@
       <div id="salesExtras" class="form-group hidden">
         <label id="setupLabel"><input type="checkbox" id="includeSetup" /> Include Setup</label>
         <label id="commissionLabel"><input type="checkbox" id="includeCommission" /> Include Commission</label>
+        <label id="setupCommissionLabel" class="hidden"><input type="checkbox" id="includeSetupCommission" /> Optional Setup &amp; Commission (Price includes delivery)</label>
       </div>
 
       <button type="button" id="addSalesItem">+ Add Item to Quote</button>


### PR DESCRIPTION
## Summary
- add hidden checkbox for optional setup & commission in sales form
- support new checkbox via script to show for specific part numbers
- include optional setup & commission note in rendered quote and PDF output

## Testing
- `node --check script.js` *(fails: SyntaxError: Unexpected token ';')*

------
https://chatgpt.com/codex/tasks/task_e_68587f8e0d28832c8dc96f6bebf5bee6