### PR TITLE
Fix disabled appearance for sales items in repair dropdown

### DIFF
--- a/script.js
+++ b/script.js
@@ -507,8 +507,16 @@ function populateRepairs() {
   const repairs = Object.keys(data[asset]?.[make]?.[model]?.[variant]?.[category] || {});
   const select = document.getElementById("repairSelect");
   repairChoices.destroy();
-  select.innerHTML = `<option value="" disabled selected>Select Repair</option>` +
-    repairs.map(r => `<option value="${r}">${r}</option>`).join("");
+  select.innerHTML =
+    `<option value="" disabled selected>Select Repair</option>` +
+    repairs
+      .map(r => {
+        const info = data[asset]?.[make]?.[model]?.[variant]?.[category]?.[r];
+        const isEq = info && info.part_number && info.part_number.startsWith("EQ");
+        const label = isEq ? `${r} (Sales Order Item)` : r;
+        return `<option value="${r}" ${isEq ? "disabled" : ""}>${label}</option>`;
+      })
+      .join("");
   repairChoices = new Choices(select, {
     searchEnabled: true,
     shouldSort: false,


### PR DESCRIPTION
## Summary
- ensure repair dropdown disables equipment sales items

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_68591c710d98832ca86dc2b272b05261