### PR TITLE
Adjust Sales Order dropdown label

### DIFF
--- a/script.js
+++ b/script.js
@@ -513,7 +513,7 @@ function populateRepairs() {
       .map(r => {
         const info = data[asset]?.[make]?.[model]?.[variant]?.[category]?.[r];
         const isEq = info && info.part_number && info.part_number.startsWith("EQ");
-        const label = isEq ? `${r} (Sales Order Item)` : r;
+        const label = isEq ? `${r} (Sales Order)` : r;
         return `<option value="${r}" ${isEq ? "disabled" : ""}>${label}</option>`;
       })
       .join("");

--- a/style.css
+++ b/style.css
@@ -94,6 +94,7 @@ select option[disabled] {
 
 .choices__item--disabled {
   opacity: 0.5;
+  color: #999;
 }
 
 .choices__list--dropdown {


### PR DESCRIPTION
## Summary
- tweak repair dropdown label to use `(Sales Order)` only
- fade disabled options more clearly in dropdown

## Testing
- `npm test` *(fails: ENOENT: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68591fc634bc832ca83433a8243b451f