### PR TITLE
Add Monarch hoist assets

### DIFF
--- a/data.json
+++ b/data.json
@@ -290,6 +290,79 @@
           }
         }
       }
+    },
+    "Portable Overhead Hoist": {
+      "Savaria": {
+        "Monarch": {
+          "Standard": {
+            "Accessories & Fittings": {
+              "Cable Retainer Monarch Portable": {
+                "labour_hours": 0.2,
+                "material_cost": 5.44,
+                "part_number": "SPX323-0130"
+              },
+              "Cabin Kit Monarch Portable": {
+                "labour_hours": 1.2,
+                "material_cost": 215.83,
+                "part_number": "SPX323-0095"
+              },
+              "Opemed Reacher Stick for Monarch Portable Hoist": {
+                "labour_hours": 0.4,
+                "material_cost": 162.45,
+                "part_number": "EQ323-0002"
+              }
+            },
+            "Controls": {
+              "Handset Monarch": {
+                "labour_hours": 0.3,
+                "material_cost": 207.11,
+                "part_number": "SPX323-0117"
+              },
+              "Monarch Keypad Membrane Left Hand": {
+                "labour_hours": 0.6,
+                "material_cost": 66.81,
+                "part_number": "SPX323-0127"
+              },
+              "Monarch Keypad Membrane Right Hand": {
+                "labour_hours": 0.6,
+                "material_cost": 66.81,
+                "part_number": "SPX323-0128"
+              }
+            },
+            "Electronics": {
+              "Pcb Assy - Monarch": {
+                "labour_hours": 1,
+                "material_cost": 252.37,
+                "part_number": "SPX323-0083"
+              }
+            },
+            "Main Unit": {
+              "Monarch Portable Hoist Pod 200kg": {
+                "labour_hours": 2,
+                "material_cost": 1595.88,
+                "part_number": "EQ323-0001"
+              }
+            },
+            "Power Supply": {
+              "Li-Ion Charger W/O Cord": {
+                "labour_hours": 0.5,
+                "material_cost": 118.32,
+                "part_number": "SPX323-0068"
+              },
+              "Power Cord Uk for Charger (auto apply when the above is selected)": {
+                "labour_hours": 0.2,
+                "material_cost": 32.0,
+                "part_number": "SPX323-0096"
+              },
+              "Battery - Monarch": {
+                "labour_hours": 0.5,
+                "material_cost": 260.0,
+                "part_number": "SPX323-0119"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "sales": {
@@ -531,6 +604,68 @@
               "Twin Braked Castor 75mm - Bradshaw Low": {
                 "cost": 10.64,
                 "price": 49.17
+              }
+            }
+          }
+        }
+      }
+    },
+    "Portable Overhead Hoist": {
+      "Savaria": {
+        "Monarch": {
+          "Standard": {
+            "Accessories & Fittings": {
+              "Cable Retainer Monarch Portable": {
+                "cost": 2.0,
+                "price": 5.44
+              },
+              "Cabin Kit Monarch Portable": {
+                "cost": 120.0,
+                "price": 215.83
+              },
+              "Opemed Reacher Stick for Monarch Portable Hoist": {
+                "cost": 99.0,
+                "price": 162.45
+              }
+            },
+            "Controls": {
+              "Handset Monarch": {
+                "cost": 69.0,
+                "price": 207.11
+              },
+              "Monarch Keypad Membrane Left Hand": {
+                "cost": 30.0,
+                "price": 66.81
+              },
+              "Monarch Keypad Membrane Right Hand": {
+                "cost": 30.0,
+                "price": 66.81
+              }
+            },
+            "Electronics": {
+              "Pcb Assy - Monarch": {
+                "cost": 135.0,
+                "price": 252.37
+              }
+            },
+            "Main Unit": {
+              "Monarch Portable Hoist Pod 200kg": {
+                "cost": 760.0,
+                "price": 1595.88
+              }
+            },
+            "Power Supply": {
+              "Li-Ion Charger W/O Cord": {
+                "cost": 39.0,
+                "price": 118.32
+              },
+              "Power Cord Uk for Charger (auto apply when the above is selected)": {
+                "cost": 10.0,
+                "price": 32.0
+              },
+              "Battery - Monarch": {
+                "cost": 195.0,
+                "price": 260.0
               }
             }
           }


### PR DESCRIPTION
## Summary
- include Portable Overhead Hoist asset data for Savaria Monarch in both repair and sales sections

## Testing
- `jq empty data.json`

------
https://chatgpt.com/codex/tasks/task_e_685935523320832cbceb453389ba153d