### PR TITLE
Add Marsden scale data and show descriptions

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,4 +1,175 @@
 {
-  "repairs": {},
-  "sales": {}
+  "repairs": {
+    "Chair Scale": {
+      "Marsden": {
+        "M-200 Bariatric Chair Scale": {
+          "Standard": {
+            "Batteries": {
+              "2000mAh replacement battery for Marsden DP-3800/DP-3810 scales – short connector": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0003",
+                "description": "Install replacement battery in M-200 Chair Scale."
+              }
+            }
+          }
+        },
+        "M-210 Chair Scale": {
+          "Standard": {
+            "Batteries": {
+              "2000mAh replacement battery for Marsden DP-3800/DP-3810 scales – short connector": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0003",
+                "description": "Install replacement battery in M-210 Chair Scale."
+              }
+            }
+          }
+        },
+        "M-225 Chair Scale": {
+          "Standard": {
+            "Batteries": {
+              "2000mAh replacement battery for Marsden DP-3800/DP-3810 scales – short connector": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0003",
+                "description": "Install replacement battery in M-225 Chair Scale."
+              }
+            }
+          }
+        },
+        "MPDC-250 Professional Chair Scale": {
+          "Standard": {
+            "Batteries": {
+              "2000mAh replacement battery for Marsden DP-3800/DP-3810 scales – short connector": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0003",
+                "description": "Install replacement battery in MPDC-250 Chair Scale."
+              }
+            }
+          }
+        },
+        "M-250 Chair Scale": {
+          "Standard": {
+            "Batteries": {
+              "Marsden Scale Battery DP-3800 (V3) Long Conn": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0004",
+                "description": "Install replacement long-connection battery in M-250 Chair Scale."
+              }
+            }
+          }
+        },
+        "M-950 Bed & Trolley Scale": {
+          "Standard": {
+            "Batteries": {
+              "Marsden Scale Battery DP-3800 (V3) Long Conn": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0004",
+                "description": "Install replacement long-connection battery in M-950 Bed & Trolley Scale."
+              }
+            }
+          }
+        },
+        "M-610 Hoist Weigher (Heavy Duty)": {
+          "Standard": {
+            "Batteries": {
+              "Marsden Scale Battery DP-3800 (V3) Long Conn": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0004",
+                "description": "Install replacement long-connection battery in M-610 Hoist Weigher."
+              }
+            }
+          }
+        }
+      }
+    },
+    "Hoist Attachment Scale": {
+      "Marsden": {
+        "M-600 Hoist Weigher Attachment": {
+          "Standard": {
+            "Batteries": {
+              "2000mAh replacement battery for Marsden DP-3800/DP-3810 scales – short connector": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0003",
+                "description": "Install replacement battery in M-600 Hoist Weigher."
+              }
+            }
+          }
+        },
+        "M-615 Hoist Weigher Attachment": {
+          "Standard": {
+            "Batteries": {
+              "Marsden Scale Battery DP-3800 (V3) Long Conn": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0004",
+                "description": "Install replacement long-connection battery in M-615 Hoist Weigher."
+              }
+            }
+          }
+        },
+        "Marsden Hoist Weigher Scale Attachment M-600 with BMI": {
+          "Standard": {
+            "Main Unit": {
+              "Marsden Hoist Weigher Scale Attachment M-600 with BMI": {
+                "labour_hours": 0,
+                "material_cost": 0,
+                "part_number": "EQ141-0004",
+                "description": "Equipment Sales"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "sales": {
+    "Chair Scale": {
+      "Marsden": {
+        "M-210 Digital Chair Scale": {
+          "Standard": {
+            "Main Unit": {
+              "Marsden Professional Chair Scale with BMI M-210": {
+                "cost": 425.0,
+                "price": 726.96,
+                "description": "Marsden Professional Chair Scale with BMI M-210"
+              }
+            }
+          }
+        },
+        "M-225  Digital Chair Scale": {
+          "Standard": {
+            "Main Unit": {
+              "Marsden Easy-Use Entry Level Chair Scale": {
+                "cost": 459.0,
+                "price": 624.0,
+                "description": "Marsden Easy-Use Entry Level Chair Scale"
+              }
+            }
+          }
+        }
+      }
+    },
+    "Hoist Attachment Scale": {
+      "Marsden": {
+        "Marsden Hoist Weigher Scale Attachment M-600 with BMI": {
+          "Standard": {
+            "Main Unit": {
+              "Marsden Hoist Weigher Scale Attachment M-600 with BMI": {
+                "cost": 569.0,
+                "price": 724.0,
+                "description": "Marsden Hoist Weigher Scale Attachment M-600 with BMI"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/index.html
+++ b/index.html
@@ -97,6 +97,10 @@
         <p class="note">Minimum labour charge per quote is £74.75.</p>
       </div>
 
+      <div id="serviceDesc" class="form-group hidden">
+        <p id="serviceDescText" class="note"></p>
+      </div>
+
       <button type="button" id="addItem">+ Add Item to Quote</button>
 
       <div class="checkboxes">

--- a/script.js
+++ b/script.js
@@ -237,6 +237,14 @@ document.addEventListener("DOMContentLoaded", () => {
     } else {
       labourInput.value = "";
     }
+    const descBox = document.getElementById("serviceDesc");
+    const descText = document.getElementById("serviceDescText");
+    if (info && info.description) {
+      descText.textContent = info.description;
+      descBox.classList.remove("hidden");
+    } else {
+      descBox.classList.add("hidden");
+    }
     document.getElementById("repairQty").value = 1;
     document.getElementById("labourSection").classList.remove("hidden");
   });
@@ -301,8 +309,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const variant = document.getElementById("salesVariantSelect").value;
     const category = document.getElementById("salesCategorySelect").value;
     const item = document.getElementById("salesItemSelect").value;
-    document.getElementById("salesDesc").value = `${asset} - ${make} - ${model} - ${variant} - ${category} - ${item}`;
     const info = salesData[asset]?.[make]?.[model]?.[variant]?.[category]?.[item];
+    document.getElementById("salesDesc").value = info?.description || `${asset} - ${make} - ${model} - ${variant} - ${category} - ${item}`;
     const repairInfo = data[asset]?.[make]?.[model]?.[variant]?.[category]?.[item];
     currentSetupCost = 0;
     currentCommissionCost = 0;


### PR DESCRIPTION
## Summary
- add Marsden batteries and scale data
- display service description when selecting a repair
- auto-fill item description in sales tab

## Testing
- `node -e 'const fs=require("fs"); JSON.parse(fs.readFileSync("data.json")); console.log("ok")'`

------
https://chatgpt.com/codex/tasks/task_e_685e6a28a19c832cb8d08e95069528d6