### PR TITLE
Add override carriage option

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,6 +215,8 @@
 
       <div class="checkboxes">
         <label><input type="checkbox" id="vatExemptSales" /> VAT Exempt</label>
+        <label><input type="checkbox" id="overrideCarriage" /> Override Carriage</label>
+        <input type="number" id="customCarriage" step="0.01" value="15.95" class="hidden" />
       </div>
     </form>
 

--- a/script.js
+++ b/script.js
@@ -45,6 +45,7 @@ let assetChoices, makeChoices, modelChoices, variantChoices, categoryChoices, re
 let salesAssetChoices, salesMakeChoices, salesModelChoices,
     salesVariantChoices, salesCategoryChoices, salesItemChoices;
 let setupLabel, commissionLabel, includeSetup, includeCommission;
+let overrideCarriage, customCarriage;
 
 document.addEventListener("DOMContentLoaded", () => {
   assetChoices = new Choices("#assetSelect", {
@@ -135,6 +136,8 @@ document.addEventListener("DOMContentLoaded", () => {
     commissionLabel = document.getElementById("commissionLabel");
     includeSetup = document.getElementById("includeSetup");
     includeCommission = document.getElementById("includeCommission");
+    overrideCarriage = document.getElementById("overrideCarriage");
+    customCarriage = document.getElementById("customCarriage");
 
   fetch('data.json')
     .then(r => r.json())
@@ -439,6 +442,16 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   document.getElementById("vatExemptSales").addEventListener("change", renderSalesQuote);
+  document.getElementById("overrideCarriage").addEventListener("change", () => {
+    const input = document.getElementById("customCarriage");
+    input.classList.toggle("hidden", !document.getElementById("overrideCarriage").checked);
+    renderSalesQuote();
+  });
+  document.getElementById("customCarriage").addEventListener("input", () => {
+    if (document.getElementById("overrideCarriage").checked) {
+      renderSalesQuote();
+    }
+  });
   document.getElementById("downloadSalesPDF").addEventListener("click", generateSalesPDF);
 });
 
@@ -1008,11 +1021,12 @@ function renderSalesQuote() {
     `;
   });
 
-  subtotal += SALES_CARRIAGE;
+  const carriage = overrideCarriage.checked ? parseFloat(customCarriage.value) || 0 : SALES_CARRIAGE;
+  subtotal += carriage;
   if (salesItems.length > 0) {
     lines.innerHTML += `
       <div class="quote-line">
-        <p><strong class="label">Carriage</strong><strong class="value">£${SALES_CARRIAGE.toFixed(2)}</strong></p>
+        <p><strong class="label">Carriage</strong><strong class="value">£${carriage.toFixed(2)}</strong></p>
       </div>
     `;
   }
@@ -1111,8 +1125,9 @@ async function generateSalesPDF() {
     ];
   });
 
+  const carriage = overrideCarriage.checked ? parseFloat(customCarriage.value) || 0 : SALES_CARRIAGE;
   if (rows.length > 0) {
-    rows.push(["Carriage", "", "", `£${SALES_CARRIAGE.toFixed(2)}`]);
+    rows.push(["Carriage", "", "", `£${carriage.toFixed(2)}`]);
   }
 
   doc.autoTable({

--- a/style.css
+++ b/style.css
@@ -320,3 +320,12 @@ input[type="checkbox"]:active {
   box-sizing: border-box;
 }
 
+#customCarriage {
+  width: 90px;
+  padding: 6px;
+  font-size: 0.95rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  box-sizing: border-box;
+}
+


### PR DESCRIPTION
## Summary
- add 'Override Carriage' checkbox and input on Sales tab
- style custom carriage field
- update JS to support overriding carriage charge in UI and PDFs

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685e6d978b98832c8b26ac01c376f0b2