### PR TITLE
Fix sales number input styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -61,7 +61,7 @@ label {
   margin-bottom: 6px;
 }
 
-input[type="text"], select {
+input[type="text"], input[type="number"], select {
   width: 100%;
   padding: 8px;
   font-size: 0.95rem;


### PR DESCRIPTION
## Summary
- ensure number inputs use the same full width styling as text inputs

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e6fe9db8c832ca9a42e782b9f4c6e