### PR TITLE
Improve quote layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,8 +113,23 @@
 
     <div id="quoteSection" class="quote-section hidden">
       <div id="workDescription" class="desc-box hidden"></div>
-      <div id="quoteLines"></div>
-      <div id="estimate"></div>
+      <div id="quoteDetails" class="quote-details">
+        <table id="quoteTable" class="quote-table">
+          <thead>
+            <tr>
+              <th>Model</th>
+              <th>Service</th>
+              <th>Part#</th>
+              <th class="num">Qty</th>
+              <th class="num">Labour</th>
+              <th class="num">Materials</th>
+              <th class="num">Total</th>
+            </tr>
+          </thead>
+          <tbody id="quoteLines"></tbody>
+        </table>
+        <div id="quoteSummary" class="quote-summary"></div>
+      </div>
       <button id="downloadPDF" class="hidden">Download PDF</button>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -710,8 +710,8 @@ function resetRepairFields() {
 }
 
 function renderQuote() {
-  const quoteLines = document.getElementById("quoteLines");
-  const estimate = document.getElementById("estimate");
+  const tableBody = document.getElementById("quoteLines");
+  const summaryBox = document.getElementById("quoteSummary");
   const descBox = document.getElementById("workDescription");
   const descValue = document.getElementById("workDesc").value.trim();
   if (descValue) {
@@ -723,7 +723,7 @@ function renderQuote() {
   const supplyOnly = document.getElementById("supplyOnly").checked;
   const vatExempt = document.getElementById("vatExempt").checked;
 
-  quoteLines.innerHTML = "";
+  tableBody.innerHTML = "";
   let subtotal = 0;
   let labourSubtotal = 0;
   const items = [];
@@ -758,36 +758,31 @@ function renderQuote() {
     const materials = info.material_cost * item.qty;
     const total = labour + materials;
     subtotal += total;
-    quoteLines.innerHTML += `
-      <div class="quote-line">
-        <p class="desc"><strong>${item.asset} → ${item.make} → ${item.model} → ${item.variant} → ${item.category} → ${item.repair}</strong></p>
-        <p><span class="label">Part #:</span><span class="value">${info.part_number}</span></p>
-        <p><span class="label">Qty:</span><span class="value">${item.qty}</span></p>
-        <p><span class="label">Labour:</span><span class="value">${supplyOnly ? 'N/A' : `£${labour.toFixed(2)}`}</span></p>
-        <p><span class="label">Materials:</span><span class="value">£${materials.toFixed(2)}</span></p>
-        <p class="total-line"><strong class="label">Total:</strong><strong class="value">£${total.toFixed(2)}</strong></p>
-        <button onclick="removeItem(${index})">Remove</button>
-      </div>
-    `;
+    const row = document.createElement('tr');
+    row.innerHTML = `
+      <td>${item.asset} ${item.model}<button class="remove-btn" onclick="removeItem(${index})">\u2716</button></td>
+      <td>${info.description || `${item.category} - ${item.repair}`}</td>
+      <td>${info.part_number}</td>
+      <td class="num">${item.qty}</td>
+      <td class="num">${supplyOnly ? 'N/A' : `£${labour.toFixed(2)}`}</td>
+      <td class="num">£${materials.toFixed(2)}</td>
+      <td class="num">£${total.toFixed(2)}</td>`;
+    tableBody.appendChild(row);
   });
 
   if (carriageCharge > 0) {
     subtotal += carriageCharge;
-    quoteLines.innerHTML += `
-      <div class="quote-line">
-        <p><strong class="label">Carriage</strong><strong class="value">£${carriageCharge.toFixed(2)}</strong></p>
-      </div>
-    `;
+    const row = document.createElement('tr');
+    row.innerHTML = `<td>Carriage</td><td></td><td></td><td></td><td></td><td></td><td class="num">£${carriageCharge.toFixed(2)}</td>`;
+    tableBody.appendChild(row);
   }
 
   const vat = vatExempt ? 0 : subtotal * 0.2;
   const grandTotal = subtotal + vat;
 
-  estimate.innerHTML = `
-    <h3>Quote Summary</h3>
-    <p>Items: ${items.length}</p>
+  summaryBox.innerHTML = `
     <p>Subtotal: £${subtotal.toFixed(2)}</p>
-    <p>VAT (${vatExempt ? "Exempt" : "20%"}): £${vat.toFixed(2)}</p>
+    <p>VAT: £${vat.toFixed(2)}</p>
     <p><strong>Total: £${grandTotal.toFixed(2)}</strong></p>
   `;
 }

--- a/style.css
+++ b/style.css
@@ -239,6 +239,37 @@ input[type="checkbox"]:active {
   box-shadow: 0 4px 10px rgba(0,0,0,0.1);
 }
 
+/* Layout for table based quote details */
+.quote-details {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  align-items: end;
+}
+
+.quote-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-size: 0.95rem;
+}
+
+.quote-table th,
+.quote-table td {
+  padding: 6px 8px;
+  border-bottom: 1px solid #ccc;
+}
+
+.quote-table th {
+  background: #f2f2f2;
+  text-align: left;
+}
+
+.quote-table th.num,
+.quote-table td.num {
+  text-align: right;
+}
+
 .quote-line {
   margin-bottom: 15px;
   background: #f9f9f9;
@@ -276,13 +307,30 @@ input[type="checkbox"]:active {
   background: #a41e1e;
 }
 
-#estimate {
+.remove-btn {
+  background: none;
+  border: none;
+  color: #c62828;
+  margin-left: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.quote-summary {
   background: #eef7ec;
   padding: 12px;
-  margin-top: 15px;
   border-left: 5px solid #4caf50;
   border-radius: 6px;
   text-align: right;
+  margin-top: 10px;
+}
+
+.quote-summary p {
+  margin: 4px 0;
+}
+
+.quote-summary p:last-child {
+  font-weight: bold;
 }
 
 .desc-box {


### PR DESCRIPTION
## Summary
- redesign quote details as a table
- add bottom-right summary box inside quote section
- style numeric fields and remove buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685eb94e6a34832c8a9dd0149e91f067