### PR TITLE
Improve quote tool fit and PDF summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,13 +116,13 @@
       <div id="quoteDetails" class="quote-details">
         <table id="quoteTable" class="quote-table">
           <colgroup>
-            <col style="width:20%" />
-            <col style="width:22%" />
-            <col style="width:13%" />
-            <col style="width:11%" />
-            <col style="width:11%" />
-            <col style="width:11%" />
-            <col style="width:11%" />
+            <col style="width:18%" />
+            <col style="width:24%" />
+            <col style="width:12%" />
+            <col style="width:8%" />
+            <col style="width:12%" />
+            <col style="width:12%" />
+            <col style="width:14%" />
           </colgroup>
           <thead>
             <tr>

--- a/index.html
+++ b/index.html
@@ -116,13 +116,13 @@
       <div id="quoteDetails" class="quote-details">
         <table id="quoteTable" class="quote-table">
           <colgroup>
-            <col style="width:18%" />
-            <col style="width:24%" />
+            <col style="width:20%" />
+            <col style="width:23%" />
             <col style="width:12%" />
             <col style="width:8%" />
             <col style="width:12%" />
             <col style="width:12%" />
-            <col style="width:14%" />
+            <col style="width:13%" />
           </colgroup>
           <thead>
             <tr>

--- a/index.html
+++ b/index.html
@@ -113,8 +113,23 @@
 
     <div id="quoteSection" class="quote-section hidden">
       <div id="workDescription" class="desc-box hidden"></div>
-      <div id="quoteLines"></div>
-      <div id="estimate"></div>
+      <div id="quoteDetails" class="quote-details">
+        <table id="quoteTable" class="quote-table">
+          <thead>
+            <tr>
+              <th>Model</th>
+              <th>Service</th>
+              <th>Part#</th>
+              <th class="num">Qty</th>
+              <th class="num">Labour</th>
+              <th class="num">Materials</th>
+              <th class="num">Total</th>
+            </tr>
+          </thead>
+          <tbody id="quoteLines"></tbody>
+        </table>
+        <div id="quoteSummary" class="quote-summary"></div>
+      </div>
       <button id="downloadPDF" class="hidden">Download PDF</button>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -115,6 +115,15 @@
       <div id="workDescription" class="desc-box hidden"></div>
       <div id="quoteDetails" class="quote-details">
         <table id="quoteTable" class="quote-table">
+          <colgroup>
+            <col style="width:20%" />
+            <col style="width:22%" />
+            <col style="width:13%" />
+            <col style="width:11%" />
+            <col style="width:11%" />
+            <col style="width:11%" />
+            <col style="width:11%" />
+          </colgroup>
           <thead>
             <tr>
               <th>Model</th>

--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@ body {
 }
 
 .container {
-  max-width: 820px;
+  max-width: 700px;
   margin: auto;
   padding: 20px;
   padding-bottom: 60px;

--- a/style.css
+++ b/style.css
@@ -242,8 +242,8 @@ input[type="checkbox"]:active {
 /* Layout for table based quote details */
 .quote-details {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 130px;
-  gap: 10px;
+  grid-template-columns: 1fr 150px;
+  gap: 0;
   align-items: end;
 }
 
@@ -268,6 +268,30 @@ input[type="checkbox"]:active {
 .quote-table th.num,
 .quote-table td.num {
   text-align: right;
+}
+
+/* set proportional column widths */
+.quote-table th:nth-child(1),
+.quote-table td:nth-child(1) {
+  width: 20%;
+}
+.quote-table th:nth-child(2),
+.quote-table td:nth-child(2) {
+  width: 22%;
+}
+.quote-table th:nth-child(3),
+.quote-table td:nth-child(3) {
+  width: 13%;
+}
+.quote-table th:nth-child(4),
+.quote-table td:nth-child(4),
+.quote-table th:nth-child(5),
+.quote-table td:nth-child(5),
+.quote-table th:nth-child(6),
+.quote-table td:nth-child(6),
+.quote-table th:nth-child(7),
+.quote-table td:nth-child(7) {
+  width: 11%;
 }
 
 .quote-line {
@@ -318,10 +342,12 @@ input[type="checkbox"]:active {
 
 .quote-summary {
   background: #eef7ec;
-  padding: 12px;
-  border-left: 5px solid #4caf50;
-  border-radius: 6px;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-left: 1px solid #ccc;
+  border-bottom-right-radius: 6px;
   text-align: right;
+  width: 150px;
   margin-top: 0;
 }
 

--- a/style.css
+++ b/style.css
@@ -242,7 +242,7 @@ input[type="checkbox"]:active {
 /* Layout for table based quote details */
 .quote-details {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 130px;
+  grid-template-columns: minmax(0, 1fr) 110px;
   gap: 0;
   align-items: end;
 }
@@ -258,6 +258,12 @@ input[type="checkbox"]:active {
 .quote-table td {
   padding: 6px 8px;
   border-bottom: 1px solid #ccc;
+  white-space: nowrap;
+}
+
+.quote-table td {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .quote-table th {
@@ -273,11 +279,11 @@ input[type="checkbox"]:active {
 /* set proportional column widths */
 .quote-table th:nth-child(1),
 .quote-table td:nth-child(1) {
-  width: 18%;
+  width: 20%;
 }
 .quote-table th:nth-child(2),
 .quote-table td:nth-child(2) {
-  width: 24%;
+  width: 23%;
 }
 .quote-table th:nth-child(3),
 .quote-table td:nth-child(3) {
@@ -295,7 +301,7 @@ input[type="checkbox"]:active {
 }
 .quote-table th:nth-child(7),
 .quote-table td:nth-child(7) {
-  width: 14%;
+  width: 13%;
 }
 
 .quote-line {
@@ -351,7 +357,7 @@ input[type="checkbox"]:active {
   border-left: 1px solid #ccc;
   border-bottom-right-radius: 6px;
   text-align: right;
-  width: 130px;
+  width: 110px;
   margin-top: 0;
 }
 

--- a/style.css
+++ b/style.css
@@ -242,7 +242,7 @@ input[type="checkbox"]:active {
 /* Layout for table based quote details */
 .quote-details {
   display: grid;
-  grid-template-columns: 1fr 150px;
+  grid-template-columns: minmax(0, 1fr) 150px;
   gap: 0;
   align-items: end;
 }
@@ -273,25 +273,29 @@ input[type="checkbox"]:active {
 /* set proportional column widths */
 .quote-table th:nth-child(1),
 .quote-table td:nth-child(1) {
-  width: 20%;
+  width: 18%;
 }
 .quote-table th:nth-child(2),
 .quote-table td:nth-child(2) {
-  width: 22%;
+  width: 24%;
 }
 .quote-table th:nth-child(3),
 .quote-table td:nth-child(3) {
-  width: 13%;
+  width: 12%;
 }
 .quote-table th:nth-child(4),
-.quote-table td:nth-child(4),
+.quote-table td:nth-child(4) {
+  width: 8%;
+}
 .quote-table th:nth-child(5),
 .quote-table td:nth-child(5),
 .quote-table th:nth-child(6),
-.quote-table td:nth-child(6),
+.quote-table td:nth-child(6) {
+  width: 12%;
+}
 .quote-table th:nth-child(7),
 .quote-table td:nth-child(7) {
-  width: 11%;
+  width: 14%;
 }
 
 .quote-line {

--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@ body {
 }
 
 .container {
-  max-width: 700px;
+  max-width: 820px;
   margin: auto;
   padding: 20px;
   padding-bottom: 60px;
@@ -239,6 +239,37 @@ input[type="checkbox"]:active {
   box-shadow: 0 4px 10px rgba(0,0,0,0.1);
 }
 
+/* Layout for table based quote details */
+.quote-details {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 130px;
+  gap: 10px;
+  align-items: end;
+}
+
+.quote-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-size: 0.95rem;
+}
+
+.quote-table th,
+.quote-table td {
+  padding: 6px 8px;
+  border-bottom: 1px solid #ccc;
+}
+
+.quote-table th {
+  background: #f2f2f2;
+  text-align: left;
+}
+
+.quote-table th.num,
+.quote-table td.num {
+  text-align: right;
+}
+
 .quote-line {
   margin-bottom: 15px;
   background: #f9f9f9;
@@ -276,13 +307,30 @@ input[type="checkbox"]:active {
   background: #a41e1e;
 }
 
-#estimate {
+.remove-btn {
+  background: none;
+  border: none;
+  color: #c62828;
+  margin-right: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.quote-summary {
   background: #eef7ec;
   padding: 12px;
-  margin-top: 15px;
   border-left: 5px solid #4caf50;
   border-radius: 6px;
   text-align: right;
+  margin-top: 0;
+}
+
+.quote-summary p {
+  margin: 4px 0;
+}
+
+.quote-summary p:last-child {
+  font-weight: bold;
 }
 
 .desc-box {

--- a/style.css
+++ b/style.css
@@ -242,7 +242,7 @@ input[type="checkbox"]:active {
 /* Layout for table based quote details */
 .quote-details {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 150px;
+  grid-template-columns: minmax(0, 1fr) 130px;
   gap: 0;
   align-items: end;
 }
@@ -351,7 +351,7 @@ input[type="checkbox"]:active {
   border-left: 1px solid #ccc;
   border-bottom-right-radius: 6px;
   text-align: right;
-  width: 150px;
+  width: 130px;
   margin-top: 0;
 }
 


### PR DESCRIPTION
## Summary
- tweak container width and quote table sizing
- move delete button to the left of Model column
- remove gap above summary and align it bottom-right
- adjust PDF summary positioning to sit at the end of the details table

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685eb94e6a34832c8a9dd0149e91f067