### PR TITLE
Improve quote summary UI

### DIFF
--- a/script.js
+++ b/script.js
@@ -767,7 +767,7 @@ function renderQuote() {
     subtotal += total;
     const row = document.createElement('tr');
     row.innerHTML = `
-      <td>${item.asset} ${item.model}<button class="remove-btn" onclick="removeItem(${index})">\u2716</button></td>
+      <td>${item.asset} ${item.model}<button class="remove-btn" title="Remove item" onclick="removeItem(${index})">\u2716</button></td>
       <td>${info.description || `${item.category} - ${item.repair}`}</td>
       <td>${info.part_number}</td>
       <td class="num">${item.qty}</td>
@@ -788,9 +788,9 @@ function renderQuote() {
   const grandTotal = subtotal + vat;
 
   summaryBox.innerHTML = `
-    <p>Subtotal: £${subtotal.toFixed(2)}</p>
-    <p>VAT: £${vat.toFixed(2)}</p>
-    <p><strong>Total: £${grandTotal.toFixed(2)}</strong></p>
+    <div class="summary-row"><span>Subtotal</span><span>£${subtotal.toFixed(2)}</span></div>
+    <div class="summary-row"><span>VAT</span><span>£${vat.toFixed(2)}</span></div>
+    <div class="summary-row total"><span>Total</span><span>£${grandTotal.toFixed(2)}</span></div>
   `;
 }
 

--- a/style.css
+++ b/style.css
@@ -308,12 +308,14 @@ input[type="checkbox"]:active {
 }
 
 .remove-btn {
-  background: none;
+  background: #c62828;
   border: none;
-  color: #c62828;
+  color: #fff;
   margin-left: 6px;
   cursor: pointer;
   font-size: 0.85rem;
+  padding: 2px 6px;
+  border-radius: 4px;
 }
 
 .quote-summary {
@@ -321,15 +323,16 @@ input[type="checkbox"]:active {
   padding: 12px;
   border-left: 5px solid #4caf50;
   border-radius: 6px;
-  text-align: right;
   margin-top: 10px;
 }
 
-.quote-summary p {
+.quote-summary .summary-row {
+  display: flex;
+  justify-content: space-between;
   margin: 4px 0;
 }
 
-.quote-summary p:last-child {
+.quote-summary .summary-row.total {
   font-weight: bold;
 }
 


### PR DESCRIPTION
## Summary
- style remove item button so it's clearly clickable
- update quote summary markup
- add layout styles for summary rows
- tweak renderQuote function to output new summary structure

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68626a3f65d8832c8d57e0d3ba830b49