### PR TITLE
Improve quote summary UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
 
     <div id="salesQuoteSection" class="quote-section hidden">
       <div id="salesQuoteLines"></div>
-      <div id="salesEstimate"></div>
+      <div id="salesEstimate" class="quote-summary"></div>
       <button id="downloadSalesPDF" class="hidden">Download PDF</button>
     </div>
   </div>

--- a/script.js
+++ b/script.js
@@ -788,6 +788,8 @@ function renderQuote() {
   const grandTotal = subtotal + vat;
 
   summaryBox.innerHTML = `
+    <h3>Quote Summary</h3>
+    <div class="summary-row"><span>Items</span><span>${items.length}</span></div>
     <div class="summary-row"><span>Subtotal</span><span>£${subtotal.toFixed(2)}</span></div>
     <div class="summary-row"><span>VAT</span><span>£${vat.toFixed(2)}</span></div>
     <div class="summary-row total"><span>Total</span><span>£${grandTotal.toFixed(2)}</span></div>
@@ -1087,10 +1089,10 @@ function renderSalesQuote() {
 
   estimate.innerHTML = `
     <h3>Quote Summary</h3>
-    <p>Items: ${salesItems.length}</p>
-    <p>Subtotal: £${subtotal.toFixed(2)}</p>
-    <p>VAT (${vatExempt ? "Exempt" : "20%"}): £${vat.toFixed(2)}</p>
-    <p><strong>Total: £${grandTotal.toFixed(2)}</strong></p>
+    <div class="summary-row"><span>Items</span><span>${salesItems.length}</span></div>
+    <div class="summary-row"><span>Subtotal</span><span>£${subtotal.toFixed(2)}</span></div>
+    <div class="summary-row"><span>VAT${vatExempt ? " (Exempt)" : ""}</span><span>£${vat.toFixed(2)}</span></div>
+    <div class="summary-row total"><span>Total</span><span>£${grandTotal.toFixed(2)}</span></div>
   `;
 }
 

--- a/style.css
+++ b/style.css
@@ -326,6 +326,11 @@ input[type="checkbox"]:active {
   margin-top: 10px;
 }
 
+.quote-summary h3 {
+  margin: 0 0 8px;
+  font-size: 1rem;
+}
+
 .quote-summary .summary-row {
   display: flex;
   justify-content: space-between;
@@ -334,6 +339,7 @@ input[type="checkbox"]:active {
 
 .quote-summary .summary-row.total {
   font-weight: bold;
+  font-size: 1.05rem;
 }
 
 .desc-box {


### PR DESCRIPTION
## Summary
- display a cleaner quote summary with heading and item count
- style sales quote summary using the same box layout
- tweak summary styles for better emphasis

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68626d3ee1c8832c9fb25024a9c490e2