### PR TITLE
Fix overlapping quote summary

### DIFF
--- a/style.css
+++ b/style.css
@@ -247,6 +247,16 @@ input[type="checkbox"]:active {
   align-items: end;
 }
 
+@media (max-width: 600px) {
+  .quote-details {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+  .quote-summary {
+    margin-top: 15px;
+  }
+}
+
 .quote-table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
## Summary
- add mobile media query for `.quote-details`
- bump margin for summary on small screens

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68652aae9e64832c8fbb992289390939