### PR TITLE
Add simple jsPDF example

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 </head>
 <body>
   <div class="container">
@@ -130,7 +131,7 @@
         </table>
         <div id="quoteSummary" class="quote-summary"></div>
       </div>
-      <button id="downloadPDF" class="hidden">Download PDF</button>
+      <button id="downloadPDF" class="hidden" onclick="generatePDF()">Download Quote PDF</button>
     </div>
 
     <form id="salesForm" class="hidden">

--- a/script.js
+++ b/script.js
@@ -929,3 +929,21 @@ async function generateSalesPDF() {
 
   doc.save("NHM_Sales_Quote.pdf");
 }
+
+// Basic PDF generator example
+async function generatePDF() {
+  const { jsPDF } = window.jspdf;
+  const doc = new jsPDF();
+
+  // Example content – this will go on the PDF
+  doc.setFontSize(16);
+  doc.text("NHM Quotation", 20, 20);
+  doc.setFontSize(12);
+  doc.text("Customer: John Smith", 20, 30);
+  doc.text("Quote ID: Q123456", 20, 40);
+  doc.text("Service: Bed Repair", 20, 50);
+  doc.text("Total: £250.00", 20, 60);
+
+  // Save the file
+  doc.save("nhm-quote.pdf");
+}


### PR DESCRIPTION
## Summary
- include jsPDF script in the page head
- add download button with `onclick` handler
- append example `generatePDF` function showing basic jsPDF usage

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68663c637524832cafbb3030ce023d35