### PR TITLE
Align disclaimer section

### DIFF
--- a/script.js
+++ b/script.js
@@ -1015,13 +1015,13 @@ async function generatePDF(quoteData) {
 
   const disclaimer =
     'This quotation is provided as a good-faith estimate for the repair of equipment and reflects approximately 95% of the anticipated total cost. Please note that this estimate is subject to change upon further inspection, parts availability, and during the formal approval process. No work will be carried out without your full knowledge and explicit approval of any changes to cost or scope. This estimate is not a final invoice and does not constitute a binding agreement until formally accepted.';
-  const discLines = doc.splitTextToSize(disclaimer, 186);
+  const discLines = doc.splitTextToSize(disclaimer, pageWidth - 24);
   const discHeight = discLines.length * 5 + 5;
   let discY = footerY - discHeight - 2;
   doc.setFontSize(10);
   doc.setTextColor(...BRAND_BLUE);
   doc.setFont(undefined, 'bold');
-  doc.text('Disclaimer:', 12, discY);
+  doc.text('Disclaimer:', pageWidth / 2, discY, { align: 'center' });
   doc.setFont(undefined, 'normal');
   doc.text(discLines, 12, discY + 5);
 
@@ -1263,13 +1263,14 @@ async function generateSalesPDF() {
 
   const disclaimer =
     'This quotation is provided as a good-faith estimate for the repair of equipment and reflects approximately 95% of the anticipated total cost. Please note that this estimate is subject to change upon further inspection, parts availability, and during the formal approval process. No work will be carried out without your full knowledge and explicit approval of any changes to cost or scope. This estimate is not a final invoice and does not constitute a binding agreement until formally accepted.';
-  const discLines = doc.splitTextToSize(disclaimer, 186);
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const discLines = doc.splitTextToSize(disclaimer, pageWidth - 24);
   const discHeight = discLines.length * 5 + 5;
   let discY = footerY - discHeight - 2;
   doc.setFontSize(10);
   doc.setTextColor(...BRAND_BLUE);
   doc.setFont(undefined, 'bold');
-  doc.text('Disclaimer:', 12, discY);
+  doc.text('Disclaimer:', pageWidth / 2, discY, { align: 'center' });
   doc.setFont(undefined, 'normal');
   doc.text(discLines, 12, discY + 5);
 


### PR DESCRIPTION
## Summary
- align disclaimer heading centrally in PDFs
- keep disclaimer text left aligned across the page

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6866d1bc6644832cb2ea281cac8c956f