### PR TITLE
Add embedded data fallback for offline quoting tool

### DIFF
--- a/embedded-data.js
+++ b/embedded-data.js
@@ -1,0 +1,646 @@
+window.NHM_EMBEDDED_DATA = {
+  "repairs": {
+    "Chair Scale": {
+      "Marsden": {
+        "M-200": {
+          "Standard": {
+            "Castors & Wheels": {
+              "Replace broken or worn castor.": {
+                "labour_hours": 0.3,
+                "material_cost": 59.61,
+                "part_number": "SPX074-0010",
+                "description": "Replace broken or worn castor."
+              }
+            },
+            "Batteries": {
+              "Replace battery.": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0004",
+                "description": "Replace battery."
+              },
+              "Install replacement battery in M-200 Chair Scale.": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0003",
+                "description": "Install replacement battery in M-200 Chair Scale."
+              }
+            },
+            "Casing": {
+              "Replace battery compartment cover.": {
+                "labour_hours": 0.2,
+                "material_cost": 18.57,
+                "part_number": "SPX141-0006",
+                "description": "Replace battery compartment cover."
+              },
+              "Replace bottom control housing.": {
+                "labour_hours": 0.5,
+                "material_cost": 85.14,
+                "part_number": "SPX141-0012",
+                "description": "Replace bottom control housing."
+              },
+              "Replace top control housing.": {
+                "labour_hours": 0.5,
+                "material_cost": 85.14,
+                "part_number": "SPX141-0011",
+                "description": "Replace top control housing."
+              }
+            }
+          }
+        },
+        "M-210": {
+          "Standard": {
+            "Castors & Wheels": {
+              "Replace broken or worn castor.": {
+                "labour_hours": 0.3,
+                "material_cost": 59.61,
+                "part_number": "SPX074-0010",
+                "description": "Replace broken or worn castor."
+              }
+            },
+            "Accessories": {
+              "Replace foam arm pad.": {
+                "labour_hours": 0.3,
+                "material_cost": 27.43,
+                "part_number": "SPX141-0005",
+                "description": "Replace foam arm pad."
+              }
+            },
+            "Batteries": {
+              "Replace battery.": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0004",
+                "description": "Replace battery."
+              },
+              "Install replacement battery in M-210 Chair Scale.": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0003",
+                "description": "Install replacement battery in M-210 Chair Scale."
+              }
+            },
+            "Casing": {
+              "Replace battery compartment cover.": {
+                "labour_hours": 0.2,
+                "material_cost": 18.57,
+                "part_number": "SPX141-0006",
+                "description": "Replace battery compartment cover."
+              },
+              "Replace bottom control housing.": {
+                "labour_hours": 0.5,
+                "material_cost": 85.14,
+                "part_number": "SPX141-0012",
+                "description": "Replace bottom control housing."
+              },
+              "Replace top control housing.": {
+                "labour_hours": 0.5,
+                "material_cost": 85.14,
+                "part_number": "SPX141-0011",
+                "description": "Replace top control housing."
+              }
+            }
+          }
+        },
+        "M-225": {
+          "Standard": {
+            "Castors & Wheels": {
+              "Replace broken or worn castor.": {
+                "labour_hours": 0.0,
+                "material_cost": 59.61,
+                "part_number": "SPX074-0010",
+                "description": "Replace broken or worn castor."
+              }
+            },
+            "Batteries": {
+              "Replace battery.": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0004",
+                "description": "Replace battery."
+              }
+            },
+            "Casing": {
+              "Replace battery compartment cover.": {
+                "labour_hours": 0.5,
+                "material_cost": 18.57,
+                "part_number": "SPX141-0006",
+                "description": "Replace battery compartment cover."
+              },
+              "Replace bottom control housing.": {
+                "labour_hours": 0.5,
+                "material_cost": 85.14,
+                "part_number": "SPX141-0012",
+                "description": "Replace bottom control housing."
+              },
+              "Replace top control housing.": {
+                "labour_hours": 0.0,
+                "material_cost": 85.14,
+                "part_number": "SPX141-0011",
+                "description": "Replace top control housing."
+              }
+            }
+          }
+        },
+        "M-250": {
+          "Standard": {
+            "Batteries": {
+              "Install replacement long-connection battery in M-250 Chair Scale.": {
+                "labour_hours": 0.3,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0004",
+                "description": "Install replacement long-connection battery in M-250 Chair Scale."
+              },
+              "Replace battery.": {
+                "labour_hours": 0.5,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0004",
+                "description": "Replace battery."
+              }
+            },
+            "Castors & Wheels": {
+              "Replace broken or worn castor.": {
+                "labour_hours": 0.0,
+                "material_cost": 59.61,
+                "part_number": "SPX074-0010",
+                "description": "Replace broken or worn castor."
+              }
+            },
+            "Casing": {
+              "Replace battery compartment cover.": {
+                "labour_hours": 0.5,
+                "material_cost": 18.57,
+                "part_number": "SPX141-0006",
+                "description": "Replace battery compartment cover."
+              },
+              "Replace bottom control housing.": {
+                "labour_hours": 0.0,
+                "material_cost": 85.14,
+                "part_number": "SPX141-0012",
+                "description": "Replace bottom control housing."
+              },
+              "Replace top control housing.": {
+                "labour_hours": 0.0,
+                "material_cost": 85.14,
+                "part_number": "SPX141-0011",
+                "description": "Replace top control housing."
+              }
+            }
+          }
+        },
+        "M-610": {
+          "Standard": {
+            "Batteries": {
+              "Install replacement long-connection battery in M-610 Hoist Weigher.": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0004",
+                "description": "Install replacement long-connection battery in M-610 Hoist Weigher."
+              }
+            }
+          }
+        },
+        "M-950": {
+          "Standard": {
+            "Batteries": {
+              "Install replacement long-connection battery in M-950 Bed & Trolley Scale.": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0004",
+                "description": "Install replacement long-connection battery in M-950 Bed & Trolley Scale."
+              }
+            }
+          }
+        },
+        "MPDC-250": {
+          "Standard": {
+            "Castors & Wheels": {
+              "Replace broken or worn castor.": {
+                "labour_hours": 0.0,
+                "material_cost": 59.61,
+                "part_number": "SPX074-0010",
+                "description": "Replace broken or worn castor."
+              }
+            },
+            "Batteries": {
+              "Install replacement battery in MPDC-250 Chair Scale.": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0003",
+                "description": "Install replacement battery in MPDC-250 Chair Scale."
+              }
+            }
+          }
+        }
+      },
+      "Seca": {
+        "664": {
+          "Standard": {
+            "Column Assembly": {
+              "Fix loose column knob on scale (Replace mast lock knob)": {
+                "labour_hours": 0.3,
+                "material_cost": 12.69,
+                "part_number": "SPX201-0070",
+                "description": "Fix loose column knob on scale (Replace mast lock knob)"
+              }
+            }
+          }
+        },
+        "955": {
+          "Standard": {
+            "Footrest": {
+              "Replace broken footrest on scale": {
+                "labour_hours": 0.3,
+                "material_cost": 39.4,
+                "part_number": "SPX201-0053",
+                "description": "Replace broken footrest on scale"
+              }
+            }
+          }
+        },
+        "958": {
+          "Standard": {
+            "Load Cell": {
+              "Replace weight sensor part on Seca 958 scale": {
+                "labour_hours": 0.5,
+                "material_cost": 0.0,
+                "part_number": "SPX201-0049",
+                "description": "Replace weight sensor part on Seca 958 scale"
+              }
+            }
+          }
+        },
+        "959": {
+          "Standard": {
+            "Keypad": {
+              "Replace button panel on scale": {
+                "labour_hours": 0.4,
+                "material_cost": 66.06,
+                "part_number": "SPX201-0087",
+                "description": "Replace button panel on scale"
+              }
+            },
+            "Batteries & Chargers": {
+              "Provide new charger for Seca 959 scale": {
+                "labour_hours": 0.2,
+                "material_cost": 160.0,
+                "part_number": "SPX102-0368",
+                "description": "Provide new charger for Seca 959 scale"
+              }
+            }
+          }
+        },
+        "941 DP Series": {
+          "Standard": {
+            "Keypad": {
+              "Replace button panel on older 941 series scale": {
+                "labour_hours": 0.4,
+                "material_cost": 101.15,
+                "part_number": "SPX201-0089",
+                "description": "Replace button panel on older 941 series scale"
+              }
+            }
+          }
+        },
+        "Universal": {
+          "Standard": {
+            "Power": {
+              "Replace power socket on Seca 685 scale": {
+                "labour_hours": 0.3,
+                "material_cost": 31.29,
+                "part_number": "SPX201-0092",
+                "description": "Replace power socket on Seca 685 scale"
+              }
+            },
+            "Control Housing": {
+              "Replace screws and fixings on the control unit": {
+                "labour_hours": 0.2,
+                "material_cost": 13.14,
+                "part_number": "SPX201-0066",
+                "description": "Replace screws and fixings on the control unit"
+              }
+            },
+            "Weighing Equipment": {
+              "Replace display screen on scale": {
+                "labour_hours": 0.4,
+                "material_cost": 184.28,
+                "part_number": "SPX017-10827",
+                "description": "Replace display screen on scale"
+              }
+            },
+            "Connections": {
+              "Replace grey plastic socket cover": {
+                "labour_hours": 0.2,
+                "material_cost": 22.04,
+                "part_number": "SPX196-0089",
+                "description": "Replace grey plastic socket cover"
+              }
+            },
+            "Load Cell": {
+              "Replace screws holding the weighing part (load cell)": {
+                "labour_hours": 0.2,
+                "material_cost": 2.91,
+                "part_number": "SPX201-0028",
+                "description": "Replace screws holding the weighing part (load cell)"
+              }
+            },
+            "Batteries & Chargers": {
+              "Provide a new 9V charger for chair scale": {
+                "labour_hours": 0.2,
+                "material_cost": 72.68,
+                "part_number": "SPX201-0013",
+                "description": "Provide a new 9V charger for chair scale"
+              },
+              "Provide a new 12V charger for chair scale": {
+                "labour_hours": 0.2,
+                "material_cost": 73.69,
+                "part_number": "SPX201-0014",
+                "description": "Provide a new 12V charger for chair scale"
+              }
+            },
+            "Footplate Assembly": {
+              "Replace metal locking pin or foot fixing part": {
+                "labour_hours": 0.3,
+                "material_cost": 0.0,
+                "part_number": "SPX201-0037",
+                "description": "Replace metal locking pin or foot fixing part"
+              }
+            },
+            "PCB Repair": {
+              "Fit a small repair board inside the scale": {
+                "labour_hours": 0.4,
+                "material_cost": 68.27,
+                "part_number": "SPX201-0084",
+                "description": "Fit a small repair board inside the scale"
+              }
+            },
+            "Side Cap Cover Replacement.": {
+              "Replace plastic side cap on chair scale": {
+                "labour_hours": 0.2,
+                "material_cost": 17.14,
+                "part_number": "SPX201-0030",
+                "description": "Replace plastic side cap on chair scale"
+              }
+            },
+            "Servicing Tool": {
+              "Provide small threading tool for maintenance upgrade": {
+                "labour_hours": 0.1,
+                "material_cost": 14.39,
+                "part_number": "SPX196-0106",
+                "description": "Provide small threading tool for maintenance upgrade"
+              }
+            }
+          }
+        }
+      }
+    },
+    "Hoist Attachment Scale": {
+      "Marsden": {
+        "M-600": {
+          "Standard": {
+            "Batteries": {
+              "Install replacement battery in M-600 Hoist Weigher.": {
+                "labour_hours": 0.2,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0003",
+                "description": "Install replacement battery in M-600 Hoist Weigher."
+              }
+            }
+          }
+        },
+        "M-615": {
+          "Standard": {
+            "Batteries": {
+              "Install replacement long-connection battery in M-615 Hoist Weigher.": {
+                "labour_hours": 0.3,
+                "material_cost": 70.94,
+                "part_number": "SPX141-0004",
+                "description": "Install replacement long-connection battery in M-615 Hoist Weigher."
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "sales": {
+    "Chair Scale": {
+      "Marsden": {
+        "M-200": {
+          "Standard": {
+            "Weighing Equipment": {
+              "Supply chair scale.": {
+                "cost": 0,
+                "price": 830.96,
+                "part_number": "EQ141-0001",
+                "description": "Supply chair scale."
+              }
+            }
+          }
+        },
+        "M-210": {
+          "Standard": {
+            "Weighing Equipment": {
+              "Supply professional chair scale.": {
+                "cost": 0,
+                "price": 726.96,
+                "part_number": "EQ141-0002",
+                "description": "Supply professional chair scale."
+              }
+            },
+            "Main Unit": {
+              "Equipment Sales": {
+                "cost": 0,
+                "price": 726.96,
+                "part_number": "EQ141-0002",
+                "description": "Equipment Sales"
+              }
+            }
+          }
+        },
+        "M-225": {
+          "Standard": {
+            "Weighing Equipment": {
+              "Supply chair scale.": {
+                "cost": 0,
+                "price": 624.0,
+                "part_number": "EQ141-0003",
+                "description": "Supply chair scale."
+              }
+            },
+            "Main Unit": {
+              "Equipment Sales": {
+                "cost": 0,
+                "price": 624.0,
+                "part_number": "EQ141-0003",
+                "description": "Equipment Sales"
+              }
+            }
+          }
+        },
+        "M-250": {
+          "Standard": {
+            "Weighing Equipment": {
+              "Supply premium chair scale.": {
+                "cost": 0,
+                "price": 1180.4,
+                "part_number": "EQ141-0010",
+                "description": "Supply premium chair scale."
+              }
+            }
+          }
+        }
+      },
+      "Seca": {
+        "955": {
+          "Standard": {
+            "Main Unit": {
+              "Provide a new chair scale (Seca 955)": {
+                "cost": 0,
+                "price": 830.96,
+                "part_number": "EQ201-0002",
+                "description": "Provide a new chair scale (Seca 955)"
+              }
+            }
+          }
+        },
+        "956": {
+          "Standard": {
+            "Main Unit": {
+              "Provide a new chair scale (Seca 956)": {
+                "cost": 0,
+                "price": 639.49,
+                "part_number": "EQ201-0003",
+                "description": "Provide a new chair scale (Seca 956)"
+              }
+            }
+          }
+        },
+        "959": {
+          "Standard": {
+            "Main Unit": {
+              "Provide a new chair scale (Seca 959)": {
+                "cost": 0,
+                "price": 799.65,
+                "part_number": "EQ201-0004",
+                "description": "Provide a new chair scale (Seca 959)"
+              }
+            }
+          }
+        }
+      }
+    },
+    "Hoist Attachment Scale": {
+      "Marsden": {
+        "M-600": {
+          "Standard": {
+            "Main Unit": {
+              "Equipment Sales": {
+                "cost": 0,
+                "price": 724.0,
+                "part_number": "EQ141-0004",
+                "description": "Equipment Sales"
+              }
+            },
+            "Weighing Equipment": {
+              "Supply hoist weigher scale.": {
+                "cost": 0,
+                "price": 724.0,
+                "part_number": "EQ141-0004",
+                "description": "Supply hoist weigher scale."
+              }
+            },
+            "Accessories": {
+              "Supply carry case.": {
+                "cost": 0,
+                "price": 46.8,
+                "part_number": "EQ141-0012",
+                "description": "Supply carry case."
+              }
+            }
+          }
+        },
+        "M-605": {
+          "Standard": {
+            "Weighing Equipment": {
+              "Supply hoist weigher scale.": {
+                "cost": 0,
+                "price": 795.6,
+                "part_number": "EQ141-0005",
+                "description": "Supply hoist weigher scale."
+              }
+            },
+            "Accessories": {
+              "Supply carry case.": {
+                "cost": 0,
+                "price": 46.8,
+                "part_number": "EQ141-0013",
+                "description": "Supply carry case."
+              }
+            }
+          }
+        }
+      }
+    },
+    "Platform Scale": {
+      "Seca": {
+        "665": {
+          "Standard": {
+            "Main Unit": {
+              "Provide a new wheelchair platform scale (Seca 665)": {
+                "cost": 0,
+                "price": 1902.1,
+                "part_number": "EQ201-0001",
+                "description": "Provide a new wheelchair platform scale (Seca 665)"
+              }
+            }
+          }
+        }
+      }
+    },
+    "Flat Scale": {
+      "Seca": {
+        "875": {
+          "Standard": {
+            "Main Unit": {
+              "Provide a new flat scale (Seca 875)": {
+                "cost": 0,
+                "price": 170.45,
+                "part_number": "EQ201-0005",
+                "description": "Provide a new flat scale (Seca 875)"
+              }
+            }
+          }
+        },
+        "877": {
+          "Standard": {
+            "Main Unit": {
+              "Provide a new flat scale (Seca 877)": {
+                "cost": 0,
+                "price": 261.97,
+                "part_number": "EQ201-0006",
+                "description": "Provide a new flat scale (Seca 877)"
+              }
+            }
+          }
+        }
+      }
+    },
+    "Hoist Scale": {
+      "Seca": {
+        "SP332": {
+          "Standard": {
+            "Main Unit": {
+              "Provide a new hoist weigher scale": {
+                "cost": 0,
+                "price": 0.0,
+                "part_number": "SPX251-0373",
+                "description": "Provide a new hoist weigher scale"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};

--- a/index.html
+++ b/index.html
@@ -266,6 +266,7 @@
   <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.25/jspdf.plugin.autotable.min.js"></script>
+  <script src="embedded-data.js"></script>
   <script src="script.js"></script>
   <footer class="rights-reserved">All rights reserved. Terry Clarke & Jamie Baker | NHM</footer>
 </body>

--- a/script.js
+++ b/script.js
@@ -32,6 +32,12 @@ const DEFAULT_COMMISSION_COST = 50;
 // Cost and default selling price for sales items
 let salesData = {};
 
+function applyLoadedData(json) {
+  if (!json || typeof json !== 'object') return;
+  data = json.repairs || {};
+  salesData = json.sales || {};
+}
+
 // Padding used for all PDF tables for consistent styling
 // Reduced from 6 to make table headers shorter
 const TABLE_PADDING = 4;
@@ -195,15 +201,24 @@ document.addEventListener("DOMContentLoaded", () => {
     overrideCarriage = document.getElementById("overrideCarriage");
     customCarriage = document.getElementById("customCarriage");
 
+  const embeddedData = window.NHM_EMBEDDED_DATA;
   fetch('data.json')
-    .then(r => r.json())
-    .then(json => {
-      data = json.repairs || {};
-      salesData = json.sales || {};
-      populateAssets();
-      populateSalesAssets();
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      return response.json();
     })
-    .catch(() => {
+    .then(json => {
+      applyLoadedData(json);
+    })
+    .catch(err => {
+      console.warn('Failed to load data.json, using embedded fallback data if available.', err);
+      if (embeddedData) {
+        applyLoadedData(embeddedData);
+      }
+    })
+    .finally(() => {
       populateAssets();
       populateSalesAssets();
     });


### PR DESCRIPTION
## Summary
- add an embedded data script so the tool still has repair and sales catalogues when the JSON fetch fails
- centralise data initialisation and fall back to the embedded copy if the network request errors
- include the embedded dataset ahead of the main script so offline use keeps dropdowns populated

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_b_68f1ff513ddc8332b74ff795c0dfadf4